### PR TITLE
Added check-env to throw an error if environment variables do not exist

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const checkEnv = require('check-env')
 const { createServer } = require('http')
 const { ApolloServer, PubSub } = require('apollo-server-express')
 const { MongoClient } = require('mongodb')
@@ -10,21 +11,16 @@ const depthLimit = require('graphql-depth-limit')
 const { createComplexityLimitRule } = require('graphql-validation-complexity')
 
 require('dotenv').config()
+// Throw an error if we don't have a required environment variable
+checkEnv(['MONGO_URI'])
 var typeDefs = readFileSync('./typeDefs.graphql', 'UTF-8')
 
 async function start() {
   const app = express()
   const MONGO_URI = process.env.MONGO_URI
   const pubsub = new PubSub()
-  let db
-
-  try {
-    const client = await MongoClient.connect(MONGO_URI, { useNewUrlParser: true })
-    db = client.db()
-  } catch (error) {
-    console.log(`MongoDB host not found; please add MONGO_URI environment variable`)
-    process.exit(1)
-  }
+  const client = await MongoClient.connect(MONGO_URI, { useNewUrlParser: true })
+  const db = client.db()
   
   const server = new ApolloServer({
     typeDefs,

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "apollo-server-express": "2.0.0",
+    "check-env": "^1.3.0",
     "cors": "^2.8.5",
     "dotenv": "6.0.0",
     "express": "4.16.3",


### PR DESCRIPTION
By adding the `check-env` module, we can introduce some quick and easy validation to have our code immediately throw errors if required environment variables have not been defined:

<img width="682" alt="screen shot 2018-12-09 at 8 10 32 pm" src="https://user-images.githubusercontent.com/4030490/49710563-23223500-fbef-11e8-849b-f5b10c881e30.png">
